### PR TITLE
Add formula display mode(s)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,3 +20,4 @@ keywords = ["xls2csv", "xls2txt", "xls", "ods", "csv"] # up to 5
 calamine = "0.19.1"
 csv = "1.1"
 clap = { version = "4.0", features = ["cargo"] }
+guard = "0.5.1"

--- a/README
+++ b/README
@@ -7,12 +7,16 @@ compatibility with terminals and command-line utilities (e.g. diff or
 less). Despite the name, they should work with both excel (xls, xlsx
 or xlsb) and OpenDocument (ods) files.
 
-The two executables provided by this package differ only in their
-default configuration: `xls2txt` and `xls2csv` both return one row per
-line, however `xls2txt` separates cells with a TAB character by
-default while `xls2csv` uses a comma (`,`): the tab separator seems
-like a better default for readability and compatibility with various
-unix utilities.
+The two executables provided by this package broadly work the same
+way, returning one line per row separated by a unix newline (`\n`) and
+quoting field values if necessary, they differ only in their *default*
+field (cell) separator:
+
+- `xls2txt` separates cells with a TAB character
+- `xls2csv` uses a comma (`,`)
+
+The tab separator seems like a better default for readability and
+compatibility with various unix utilities.
 
 ## Interface
 
@@ -30,7 +34,19 @@ their default:
 * `--field-separator` (`--fs`, `f`) is the separator used between
   sheet cells, it defaults to a TAB character for `xsl2txt` and a
   COMMA for `xls2csv`.
+* `--formula` specifies the *formula display mode*:
+  - by default (`cached-value`), formulas are not displayed, if a
+    formula cell has a cached value that is displayed, otherwise the
+    cell is empty
+  - `if-empty` will show the cached value if there is one, but will
+    show the formula if there isn't one
+  - `always` will always display the formula of a formula cell, never
+    the cached value
 * the converted data is written to stdout
+* error messages can be written to stdout, including on success
+  e.g. if an error occurs while parsing formulas and the formula mode
+  is not the default, an error will be signaled then the formula mode
+  will be reset to default
 * returns `0` if the entire conversion succeeded, `1` otherwise:
 
     - no input file was provided
@@ -66,6 +82,11 @@ or `git diff` rather than get an unhelpful "binary files differ":
         git config --global diff.spreadsheet.textconv xls2txt
 
 ## Changelog
+
+* Add support for displaying formulas
+
+  - if there is no cached value for a formula cell
+  - or instead of the cached value
 
 ### 1.0.2
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![deny(clippy::all)]
-#![warn(clippy::pedantic)]
 #![allow(clippy::similar_names)]
 
 use calamine::{open_workbook_auto, DataType, Reader};
 use clap::{builder::Arg, command};
+use guard::guard;
 use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter, Write};
 use std::io;
@@ -58,6 +58,27 @@ fn separator_to_byte(s: &str) -> Result<u8, Errors> {
     (c as u32).try_into().map_err(|_| Errors::InvalidSeparator)
 }
 
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+enum FormulaMode {
+    CachedValue,
+    IfEmpty,
+    Always,
+    // Evaluate
+}
+impl clap::ValueEnum for FormulaMode {
+    fn value_variants<'a>() -> &'a [Self] {
+        &[Self::CachedValue, Self::IfEmpty, Self::Always]
+    }
+
+    fn to_possible_value<'a>(&self) -> Option<clap::builder::PossibleValue> {
+        match self {
+            Self::CachedValue => Some(clap::builder::PossibleValue::new("cached-value")),
+            Self::IfEmpty => Some(clap::builder::PossibleValue::new("if-empty")),
+            Self::Always => Some(clap::builder::PossibleValue::new("always")),
+        }
+    }
+}
+
 pub fn run(
     n: &'static str,
     default_rs: &'static str,
@@ -101,6 +122,21 @@ Should be able to convert from (and automatically guess between) XLS, XLSX, XLSB
                 .default_value(default_fs)
                 .help("Field separator (a single character)"),
         )
+        .arg(
+            Arg::new("formula-mode")
+                .long("formula")
+                .value_parser(clap::builder::EnumValueParser::<FormulaMode>::new())
+                .default_value("cached-value")
+                .help(
+                    "\
+Whether and when to show formulas
+
+- cached-value: never show formula, always display cached value, even if empty
+- if-empty: show formula if cached-value is empty or absent
+- always: always show formula for formula cells (ignore cached value)\
+",
+                ),
+        )
         .get_matches();
 
     let rs = separator_to_byte(
@@ -126,10 +162,46 @@ Should be able to convert from (and automatically guess between) XLS, XLSX, XLSB
             .map_or(sheet, |s| s as &str),
     );
 
-    let range = if let Some(Ok(r)) = workbook.worksheet_range(&name) {
-        r
-    } else {
+    guard!(let Some(Ok(range)) = workbook.worksheet_range(&name) else {
         return Err(Errors::NotFound(name));
+    });
+    guard!(let Some((offset_j, offset_i)) = range.start() else {
+        return Ok(());
+    });
+
+    let formula_mode = *matches.get_one::<FormulaMode>("formula-mode").unwrap();
+    let wb = workbook
+        .worksheet_formula(&name)
+        .expect("we know the sheet exists");
+    let formatter: Box<dyn Fn(u32, u32, DataType) -> DataType> = match wb.as_ref() {
+        Ok(f) => match formula_mode {
+            FormulaMode::CachedValue => Box::new(|_, _, cell| cell),
+            FormulaMode::IfEmpty => Box::new(|i, j, cell| {
+                let formula = f.get_value((j, i)).filter(|s| !s.is_empty());
+                match cell {
+                    DataType::Empty => {
+                        formula.map_or(DataType::Empty, |v| DataType::String(v.to_string()))
+                    }
+
+                    DataType::String(s) if s.is_empty() => {
+                        formula.map_or(DataType::Empty, |v| DataType::String(v.to_string()))
+                    }
+
+                    rest => rest,
+                }
+            }),
+            FormulaMode::Always => Box::new(|j, i, cell| {
+                f.get_value((i, j))
+                    .filter(|s| !s.is_empty())
+                    .map_or(cell, |s| DataType::String(s.to_string()))
+            }),
+        },
+        Err(e) => {
+            if formula_mode != FormulaMode::CachedValue {
+                eprintln!("Formula parsing error: {e:?}");
+            }
+            Box::new(|_, _, cell| cell)
+        }
     };
 
     let stdout = io::stdout();
@@ -139,13 +211,15 @@ Should be able to convert from (and automatically guess between) XLS, XLSX, XLSB
         .from_writer(stdout.lock());
 
     let mut contents = vec![String::new(); range.width()];
-    for row in range.rows() {
-        for (c, cell) in row.iter().zip(contents.iter_mut()) {
+    for (j, row) in range.rows().enumerate() {
+        for (i, (c, cell)) in row.iter().zip(contents.iter_mut()).enumerate() {
             cell.clear();
-            match c {
-                DataType::Error(e) => return Err(Errors::CellError(e.clone())),
+            match formatter(i as u32 + offset_i, j as u32 + offset_j, c.clone()) {
+                DataType::Error(e) => return Err(Errors::CellError(e)),
+                // don't bother updating cell for empty
+                DataType::Empty => (),
                 // don't go through fmt for strings
-                DataType::String(s) => cell.push_str(s),
+                DataType::String(s) => cell.push_str(&s),
                 rest => write!(cell, "{}", rest)
                     .expect("formatting basic types to a string should never fail"),
             };


### PR DESCRIPTION
The default remains to display cell values, including cache / placeholder if there is one for a formula cell.

The two new options are:

- display the formula if the cell has no cached value (or the cached value is empty)
- display the formula if there is one for the cell

Closes #1 